### PR TITLE
Add X-compilation instructions to bubbler

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ git clone https://github.com/ComputerScienceHouse/bubbler
 
 Build bubbler:
 
+#### Compilation
+
 ```bash
 cargo build --release
+```
+
+#### Cross compilation
+
+Bubbler supports `cross`. To cross-compile for ARM, simply run
+
+```bash
+cargo install cross
+cross build --target=armv7-unknown-linux-gnueabihf --release
 ```
 
 Copy `.env.example` to `.env`


### PR DESCRIPTION
This project works with `cross`. Insert a blurb into the README about that.