### PR TITLE
Explicitly use a Mutex to prevent simultaneous drops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.env

--- a/mock-owfs.sh
+++ b/mock-owfs.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -o xtrace
+
+source .env
+
+sudo mkdir -p "/mnt/w1"
+user="$(id -un)"
+group="$(id -gn)"
+sudo chown -R $user:$group /mnt/w1
+
+IFS=','
+
+read -ra addresses <<< "$BUB_SLOT_ADDRESSES"
+
+for address in "${addresses[@]}"; do
+    mkdir -p "/mnt/w1/$address"
+    touch "/mnt/w1/$address/id"
+done
+
+address="$BUB_TEMP_ADDRESS"
+
+mkdir -p "/mnt/w1/$address"
+echo 4 | tee "/mnt/w1/$address/temperature12" >/dev/null

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,22 @@
 extern crate actix_web;
 
 use actix_web::{web, App, HttpServer};
-use std::sync::Mutex;
 
 pub mod routes;
 use routes::config::{AppData, ConfigData};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    ConfigData::new().initialize_slots().unwrap();
+    let config_data = ConfigData::new();
+    config_data.initialize_slots().unwrap();
 
-    HttpServer::new(|| {
+    let app_data = web::Data::new(AppData {
+        config: config_data
+    });
+
+    HttpServer::new(move || {
         App::new()
-            .app_data(
-                web::Data::new(Mutex::new(AppData {
-                    config: ConfigData::new()
-                }))
-            )
+            .app_data(app_data.clone())
             .service(routes::drop)
             .service(routes::health)
             .service(routes::get_slots)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 extern crate actix_web;
 
+use std::sync::{Arc, Mutex};
+
 use actix_web::{web, App, HttpServer};
 
 pub mod routes;
@@ -11,7 +13,8 @@ async fn main() -> std::io::Result<()> {
     config_data.initialize_slots().unwrap();
 
     let app_data = web::Data::new(AppData {
-        config: config_data
+        config: config_data,
+        drop_lock: Arc::new(Mutex::new(())),
     });
 
     HttpServer::new(move || {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3,7 +3,6 @@ extern crate serde_json;
 use actix_web::{get, post, web, HttpResponse, Responder};
 use actix_web::http::StatusCode;
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
 
 pub mod machine;
 pub mod config;
@@ -39,8 +38,8 @@ struct DropErrorRes {
 }
 
 #[post("/drop")]
-async fn drop(data: web::Data<Mutex<AppData>>, req_body: web::Json<DropRequest>) -> impl Responder {
-    match machine::drop(data.lock().unwrap().config.clone(), req_body.slot) {
+async fn drop(data: web::Data<AppData>, req_body: web::Json<DropRequest>) -> impl Responder {
+    match machine::drop(data.config.clone(), req_body.slot) {
         Ok(_) => HttpResponse::Ok().json(DropResponse {
             message: "Dropped drink from slot ".to_string() + &req_body.slot.to_string()
         }),
@@ -60,9 +59,9 @@ async fn drop(data: web::Data<Mutex<AppData>>, req_body: web::Json<DropRequest>)
 }
 
 #[get("/health")]
-async fn health(data: web::Data<Mutex<AppData>>) -> impl Responder {
-    let slots = machine::get_slots_old(data.lock().unwrap().config.clone());
-    let temperature = machine::get_temperature(data.lock().unwrap().config.clone());
+async fn health(data: web::Data<AppData>) -> impl Responder {
+    let slots = machine::get_slots_old(data.config.clone());
+    let temperature = machine::get_temperature(data.config.clone());
 
     let temperature = temperature * (9.0/5.0) + 32.0;
 
@@ -73,9 +72,9 @@ async fn health(data: web::Data<Mutex<AppData>>) -> impl Responder {
 }
 
 #[get("/slots")]
-async fn get_slots(data: web::Data<Mutex<AppData>>) -> impl Responder {
-    let slots = machine::get_slots(data.lock().unwrap().config.clone());
-    let temp = machine::get_temperature(data.lock().unwrap().config.clone());
+async fn get_slots(data: web::Data<AppData>) -> impl Responder {
+    let slots = machine::get_slots(data.config.clone());
+    let temp = machine::get_temperature(data.config.clone());
 
     HttpResponse::Ok().json(SlotReport {
         slots,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -39,6 +39,8 @@ struct DropErrorRes {
 
 #[post("/drop")]
 async fn drop(data: web::Data<AppData>, req_body: web::Json<DropRequest>) -> impl Responder {
+    let drop_lock = (*data.drop_lock).lock().unwrap();
+
     match machine::drop(data.config.clone(), req_body.slot) {
         Ok(_) => HttpResponse::Ok().json(DropResponse {
             message: "Dropped drink from slot ".to_string() + &req_body.slot.to_string()

--- a/src/routes/config.rs
+++ b/src/routes/config.rs
@@ -9,8 +9,8 @@ pub struct ConfigData {
 }
 
 impl ConfigData {
-    pub fn initialize_slots(self: ConfigData) -> std::io::Result<()> {
-        for slot in self.slot_ids {
+    pub fn initialize_slots(self: &ConfigData) -> std::io::Result<()> {
+        for slot in self.clone().slot_ids {
             if slot.len() <= 4 {
                 fs::write(
                     "/sys/class/gpio/export",
@@ -49,6 +49,7 @@ impl ConfigData {
     }
 }
 
+#[derive(Clone)]
 pub struct AppData {
     pub config: ConfigData
 }

--- a/src/routes/config.rs
+++ b/src/routes/config.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs;
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
 pub struct ConfigData {
@@ -51,5 +52,6 @@ impl ConfigData {
 
 #[derive(Clone)]
 pub struct AppData {
-    pub config: ConfigData
+    pub config: ConfigData,
+    pub drop_lock: Arc<Mutex<()>>,
 }


### PR DESCRIPTION
Oops this actually includes three changes

b4b3a4ddcf25e7427968f2db2d2bc666b1e8a497 adds a script that reads from `.env` and creates a mock owfs layout for easier testing
3a8a9db711ca6ed47dfd601696e1321a4266871e moves the initialization of AppData to outside the application factory per [docs.rs/actix-web](https://docs.rs/actix-web/latest/actix_web/struct.App.html#shared-mutable-state)
7f6592e100d2b30c19e7cd83597578703ba947a2 adds a `Mutex<()>` to AppData and changes the `Mutex<AppData>` to `AppData` in route function signatures to prevent simultaneous drops. This was the original goal of the pull request.